### PR TITLE
運営からの通知を表示できるようにする

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -5,5 +5,6 @@ class HomeController < PrivateController
                      .where.not(sent_at: nil)
                      .order(sent_at: :desc)
                      .limit(100)
+    @notification_from_admins = Notification::FromAdmin.for_display
   end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+class NotificationsController < PrivateController
+  before_action :set_notification, only: %i(show)
+
+  def show
+  end
+
+  private
+
+  def set_notification
+    @notification = Notification.find(params[:id])
+  end
+end

--- a/app/models/concerns/notification_detail.rb
+++ b/app/models/concerns/notification_detail.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+module NotificationDetail
+  def self.[](type)
+    Module.new do
+      extend ActiveSupport::Concern
+
+      included do
+        belongs_to :notification
+        before_create :create_notification
+
+        define_method :create_notification do
+          self.notification = Notification.create(type: type)
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/notification_detail.rb
+++ b/app/models/concerns/notification_detail.rb
@@ -6,10 +6,16 @@ module NotificationDetail
 
       included do
         belongs_to :notification
-        before_create :create_notification
+        validates :notification, presence: true
+        delegate :title, to: :notification
+      end
 
-        define_method :create_notification do
-          self.notification = Notification.create(type: type)
+      class_methods do
+        define_method :create_with_parent do |title:, **attributes|
+          Notification.transaction do
+            notification = Notification.create(type: type, title: title)
+            create(notification: notification, **attributes)
+          end
         end
       end
     end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -5,6 +5,7 @@
 #
 #  id         :integer          not null, primary key
 #  type       :integer          not null
+#  title      :string(64)       not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
@@ -19,5 +20,5 @@ class Notification < ApplicationRecord
     from_admin: 1,
   }
 
-  validates :type, presence: true
+  validates :type, :title, presence: true
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id         :integer          not null, primary key
+#  type       :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class Notification < ApplicationRecord
+  # STI使わないので `type` カラムを退避
+  self.inheritance_column = :sti_type
+
+  enum type: {
+    from_admin: 1,
+  }
+
+  validates :type, presence: true
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -13,6 +13,8 @@ class Notification < ApplicationRecord
   # STI使わないので `type` カラムを退避
   self.inheritance_column = :sti_type
 
+  has_one :from_admin, class_name: 'Notification::FromAdmin'
+
   enum type: {
     from_admin: 1,
   }

--- a/app/models/notification/from_admin.rb
+++ b/app/models/notification/from_admin.rb
@@ -5,7 +5,6 @@
 #
 #  id              :integer          not null, primary key
 #  notification_id :integer          not null
-#  title           :string(64)       not null
 #  body            :text(65535)
 #  display_limit   :date             not null
 #  created_at      :datetime         not null
@@ -23,7 +22,7 @@
 class Notification::FromAdmin < ApplicationRecord
   include NotificationDetail[:from_admin]
 
-  validates :title, :body, presence: true
+  validates :body, presence: true
 
   scope :for_display, -> { where(display_limit: Time.zone.today..Float::INFINITY) }
 end

--- a/app/models/notification/from_admin.rb
+++ b/app/models/notification/from_admin.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: notification_from_admins
+#
+#  id              :integer          not null, primary key
+#  notification_id :integer          not null
+#  title           :string(64)       not null
+#  body            :text(65535)
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+# Indexes
+#
+#  index_notification_from_admins_on_notification_id  (notification_id)
+#
+# Foreign Keys
+#
+#  fk_rails_578e90f969  (notification_id => notifications.id)
+#
+
+class Notification::FromAdmin < ApplicationRecord
+  include NotificationDetail[:from_admin]
+
+  validates :title, :body, presence: true
+end

--- a/app/models/notification/from_admin.rb
+++ b/app/models/notification/from_admin.rb
@@ -6,7 +6,7 @@
 #  id              :integer          not null, primary key
 #  notification_id :integer          not null
 #  body            :text(65535)
-#  display_limit   :date             not null
+#  expiration_date :date             not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #
@@ -24,5 +24,5 @@ class Notification::FromAdmin < ApplicationRecord
 
   validates :body, presence: true
 
-  scope :for_display, -> { where(display_limit: Time.zone.today..Float::INFINITY) }
+  scope :for_display, -> { where(expiration_date: Time.zone.today..Float::INFINITY) }
 end

--- a/app/models/notification/from_admin.rb
+++ b/app/models/notification/from_admin.rb
@@ -7,6 +7,7 @@
 #  notification_id :integer          not null
 #  title           :string(64)       not null
 #  body            :text(65535)
+#  display_limit   :date             not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #
@@ -23,4 +24,6 @@ class Notification::FromAdmin < ApplicationRecord
   include NotificationDetail[:from_admin]
 
   validates :title, :body, presence: true
+
+  scope :for_display, -> { where(display_limit: Time.zone.today..Float::INFINITY) }
 end

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -1,5 +1,14 @@
 = render 'shared/nippos/notice_draft'
 
+- if @notification_from_admins.present?
+  .alert.alert-info.alert-dismissible role="alert"
+    button.close type="button" data-dismiss="alert" aria-label="Close"
+      span aria-hidden="true"
+        | &times;
+    ul
+      - @notification_from_admins.each do |from_admin|
+        li = link_to from_admin.title, from_admin.notification
+
 .btn-group-vertical.col-md-12
   - @recent_nippos.each do |nippo|
     = link_to nippo.dated_subject, nippo, class: 'btn btn-raised', style: 'text-align:left !important'

--- a/app/views/notifications/_from_admin.html.slim
+++ b/app/views/notifications/_from_admin.html.slim
@@ -1,0 +1,3 @@
+h3 = from_admin.title
+
+.well = auto_link(from_admin.body, :all, target: '_blank').gsub(/(\r\n|\r|\n)/, '<br>').html_safe

--- a/app/views/notifications/show.html.slim
+++ b/app/views/notifications/show.html.slim
@@ -1,0 +1,3 @@
+- case @notification.type
+- when 'from_admin'
+  = render partial: 'notifications/from_admin', locals: { from_admin: @notification.from_admin }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
     constraints: SubmitNameConstraint.new(:draft)
 
   resources :nippos, only: %i(new create show update)
+  resources :notifications, only: %i(show)
 
   devise_for :users, controllers: {
     omniauth_callbacks: 'users/omniauth_callbacks',

--- a/db/migrate/20161022024600_create_notifications.rb
+++ b/db/migrate/20161022024600_create_notifications.rb
@@ -1,0 +1,9 @@
+class CreateNotifications < ActiveRecord::Migration[5.0]
+  def change
+    create_table :notifications do |t|
+      t.integer 'type', limit: 1,  null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20161022024600_create_notifications.rb
+++ b/db/migrate/20161022024600_create_notifications.rb
@@ -2,6 +2,7 @@ class CreateNotifications < ActiveRecord::Migration[5.0]
   def change
     create_table :notifications do |t|
       t.integer 'type', limit: 1,  null: false
+      t.string 'title', limit: 64, null: false
 
       t.timestamps
     end

--- a/db/migrate/20161022025309_create_notification_from_admins.rb
+++ b/db/migrate/20161022025309_create_notification_from_admins.rb
@@ -1,0 +1,12 @@
+class CreateNotificationFromAdmins < ActiveRecord::Migration[5.0]
+  def change
+    create_table :notification_from_admins do |t|
+      t.belongs_to :notification, foreign_key: true, null: false
+
+      t.string 'title', limit: 64, null: false
+      t.text   'body'
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20161022025309_create_notification_from_admins.rb
+++ b/db/migrate/20161022025309_create_notification_from_admins.rb
@@ -3,7 +3,6 @@ class CreateNotificationFromAdmins < ActiveRecord::Migration[5.0]
     create_table :notification_from_admins do |t|
       t.belongs_to :notification, foreign_key: true, null: false
 
-      t.string 'title', limit: 64, null: false
       t.text   'body'
       t.date   'display_limit', null: false
 

--- a/db/migrate/20161022025309_create_notification_from_admins.rb
+++ b/db/migrate/20161022025309_create_notification_from_admins.rb
@@ -5,6 +5,7 @@ class CreateNotificationFromAdmins < ActiveRecord::Migration[5.0]
 
       t.string 'title', limit: 64, null: false
       t.text   'body'
+      t.date   'display_limit', null: false
 
       t.timestamps
     end

--- a/db/migrate/20161022025309_create_notification_from_admins.rb
+++ b/db/migrate/20161022025309_create_notification_from_admins.rb
@@ -4,7 +4,7 @@ class CreateNotificationFromAdmins < ActiveRecord::Migration[5.0]
       t.belongs_to :notification, foreign_key: true, null: false
 
       t.text   'body'
-      t.date   'display_limit', null: false
+      t.date   'expiration_date', null: false
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 20161022025309) do
     t.integer  "notification_id",               null: false
     t.string   "title",           limit: 64,    null: false
     t.text     "body",            limit: 65535
+    t.date     "display_limit",                 null: false
     t.datetime "created_at",                    null: false
     t.datetime "updated_at",                    null: false
     t.index ["notification_id"], name: "index_notification_from_admins_on_notification_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160617063534) do
+ActiveRecord::Schema.define(version: 20161022025309) do
 
   create_table "nippos", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
     t.integer  "user_id",                                null: false
@@ -24,6 +24,21 @@ ActiveRecord::Schema.define(version: 20160617063534) do
     t.index ["sent_at"], name: "index_nippos_on_sent_at", using: :btree
     t.index ["user_id", "reported_for"], name: "index_nippos_on_user_id_and_reported_for", unique: true, using: :btree
     t.index ["user_id"], name: "index_nippos_on_user_id", using: :btree
+  end
+
+  create_table "notification_from_admins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
+    t.integer  "notification_id",               null: false
+    t.string   "title",           limit: 64,    null: false
+    t.text     "body",            limit: 65535
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
+    t.index ["notification_id"], name: "index_notification_from_admins_on_notification_id", using: :btree
+  end
+
+  create_table "notifications", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
+    t.integer  "type",       limit: 1, null: false
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
   end
 
   create_table "reactions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
@@ -73,6 +88,7 @@ ActiveRecord::Schema.define(version: 20160617063534) do
   end
 
   add_foreign_key "nippos", "users"
+  add_foreign_key "notification_from_admins", "notifications"
   add_foreign_key "reactions", "nippos"
   add_foreign_key "reactions", "users"
   add_foreign_key "templates", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,7 +29,7 @@ ActiveRecord::Schema.define(version: 20161022025309) do
   create_table "notification_from_admins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
     t.integer  "notification_id",               null: false
     t.text     "body",            limit: 65535
-    t.date     "display_limit",                 null: false
+    t.date     "expiration_date",               null: false
     t.datetime "created_at",                    null: false
     t.datetime "updated_at",                    null: false
     t.index ["notification_id"], name: "index_notification_from_admins_on_notification_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,7 +28,6 @@ ActiveRecord::Schema.define(version: 20161022025309) do
 
   create_table "notification_from_admins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
     t.integer  "notification_id",               null: false
-    t.string   "title",           limit: 64,    null: false
     t.text     "body",            limit: 65535
     t.date     "display_limit",                 null: false
     t.datetime "created_at",                    null: false
@@ -37,9 +36,10 @@ ActiveRecord::Schema.define(version: 20161022025309) do
   end
 
   create_table "notifications", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer  "type",       limit: 1, null: false
-    t.datetime "created_at",           null: false
-    t.datetime "updated_at",           null: false
+    t.integer  "type",       limit: 1,  null: false
+    t.string   "title",      limit: 64, null: false
+    t.datetime "created_at",            null: false
+    t.datetime "updated_at",            null: false
   end
 
   create_table "reactions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+RSpec.describe NotificationsController do
+  describe 'GET show from_admin' do
+    let(:notification) { FG.create(:notification_from_admin) }
+
+    it 'returns OK' do
+      get :show, params: { id: notification.id }
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/factories/notification_from_admins.rb
+++ b/spec/factories/notification_from_admins.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 FactoryGirl.define do
   factory :notification_from_admin, class: 'Notification::FromAdmin' do
-    title { FFaker::Lorem.characters(32) }
-    body { FFaker::Lorem.paragraph }
+    title         { FFaker::Lorem.characters(32) }
+    body          { FFaker::Lorem.paragraph }
+    display_limit { Time.zone.today + rand(20) }
   end
 end

--- a/spec/factories/notification_from_admins.rb
+++ b/spec/factories/notification_from_admins.rb
@@ -2,7 +2,7 @@
 FactoryGirl.define do
   factory :notification_from_admin, class: 'Notification::FromAdmin' do
     notification
-    body          { FFaker::Lorem.paragraph }
-    display_limit { Time.zone.today + rand(20) }
+    body            { FFaker::Lorem.paragraph }
+    expiration_date { Time.zone.today + rand(20) }
   end
 end

--- a/spec/factories/notification_from_admins.rb
+++ b/spec/factories/notification_from_admins.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 FactoryGirl.define do
   factory :notification_from_admin, class: 'Notification::FromAdmin' do
-    title { FFaker::Lorem.sentence }
+    title { FFaker::Lorem.characters(32) }
     body { FFaker::Lorem.paragraph }
   end
 end

--- a/spec/factories/notification_from_admins.rb
+++ b/spec/factories/notification_from_admins.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :notification_from_admin, class: 'Notification::FromAdmin' do
+    title { FFaker::Lorem.sentence }
+    body { FFaker::Lorem.paragraph }
+  end
+end

--- a/spec/factories/notification_from_admins.rb
+++ b/spec/factories/notification_from_admins.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 FactoryGirl.define do
   factory :notification_from_admin, class: 'Notification::FromAdmin' do
-    title         { FFaker::Lorem.characters(32) }
+    notification
     body          { FFaker::Lorem.paragraph }
     display_limit { Time.zone.today + rand(20) }
   end

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 FactoryGirl.define do
   factory :notification do
-    type { Notification.types.keys.sample }
+    type   { Notification.types.keys.sample }
+    title  { FFaker::Lorem.characters(32) }
   end
 end

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :notification do
+    type { Notification.types.keys.sample }
+  end
+end

--- a/spec/models/notification/from_admin_spec.rb
+++ b/spec/models/notification/from_admin_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe Notification::FromAdmin do
   end
 
   describe 'scope :for_display' do
-    let!(:past_notification)    { FG.create(:notification_from_admin, display_limit: Time.zone.today - 1) }
-    let!(:current_notification) { FG.create(:notification_from_admin, display_limit: Time.zone.today) }
+    let!(:past_notification)    { FG.create(:notification_from_admin, expiration_date: Time.zone.today - 1) }
+    let!(:current_notification) { FG.create(:notification_from_admin, expiration_date: Time.zone.today) }
 
     subject { Notification::FromAdmin.for_display }
 

--- a/spec/models/notification/from_admin_spec.rb
+++ b/spec/models/notification/from_admin_spec.rb
@@ -4,12 +4,15 @@ RSpec.describe Notification::FromAdmin do
 
   it { is_expected.to be_valid }
 
-  context 'when after create' do
-    before { subject.save }
+  describe '.create_with_parent' do
+    it 'creates self instance with parent notification' do
+      result = Notification::FromAdmin.create_with_parent(
+        title: 'title',
+        **FG.attributes_for(:notification_from_admin),
+      )
 
-    it 'creates notification automatically' do
-      expect(subject.notification).to be_present
-      expect(subject.notification.type).to eq 'from_admin'
+      expect(result.notification).not_to be_nil
+      expect(result.notification.title).to eq 'title'
     end
   end
 

--- a/spec/models/notification/from_admin_spec.rb
+++ b/spec/models/notification/from_admin_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+RSpec.describe Notification::FromAdmin do
+  subject { FG.build(:notification_from_admin) }
+
+  it { is_expected.to be_valid }
+
+  context 'when after create' do
+    before { subject.save }
+
+    it 'creates notification automatically' do
+      expect(subject.notification).to be_present
+      expect(subject.notification.type).to eq 'from_admin'
+    end
+  end
+end

--- a/spec/models/notification/from_admin_spec.rb
+++ b/spec/models/notification/from_admin_spec.rb
@@ -12,4 +12,14 @@ RSpec.describe Notification::FromAdmin do
       expect(subject.notification.type).to eq 'from_admin'
     end
   end
+
+  describe 'scope :for_display' do
+    let!(:past_notification)    { FG.create(:notification_from_admin, display_limit: Time.zone.today - 1) }
+    let!(:current_notification) { FG.create(:notification_from_admin, display_limit: Time.zone.today) }
+
+    subject { Notification::FromAdmin.for_display }
+
+    it { is_expected.not_to include(past_notification) }
+    it { is_expected.to     include(current_notification) }
+  end
 end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+RSpec.describe Notification, type: :model do
+  subject { FG.build(:notification) }
+
+  it { is_expected.to be_valid }
+end


### PR DESCRIPTION
- とりあえず「運営」=「おれ」なので、かっこいい管理画面は不要
- 最新の通知へのリンクをTOPページに出す
- リンクを押すと通知の詳細を見れる
- 「通知【Notification】」というエンティティは今後範囲を拡張する予定なのでそのつもりで作る